### PR TITLE
handle symbols that look like types #5

### DIFF
--- a/src/parser/defs.ts
+++ b/src/parser/defs.ts
@@ -154,6 +154,12 @@ export const types = [
 ];
 export const typesSet = new Set(types);
 
+export const typesAllowAsVarNames = [
+  "status",
+  "symbol"
+];
+export const typesAllowAsVarNamesSet = new Set(typesAllowAsVarNames);
+
 export const modifiers_function = [
   "private",
   "protected",

--- a/src/plugin/print/tests/index.spec.ts
+++ b/src/plugin/print/tests/index.spec.ts
@@ -419,6 +419,19 @@ describe("prettier-lpc plugin", () => {
     expect(formatted).toMatchSnapshot("function-stub-with-newline-comments");
   });
 
+  test("format variables that look like types", () => {
+    let formatted = format(
+      `void somefunc() { string status; status = sprintf("Stutus number: %d\n", status); }`
+    );
+    expect(formatted).toMatchInlineSnapshot(`
+      "void somefunc() {
+        string status;
+        status = sprintf("Stutus number: %d
+      ", status);
+      }"
+    `);
+  });
+
   test("format assignment expressions", () => {
     let formatted = format(assign_exp_suffix_comment);
     expect(formatted).toMatchSnapshot("assign_exp_suffix_comment");


### PR DESCRIPTION
Handle symbols (like `status`) that are also valid type names.