### PR TITLE
parse suffix comments after text formatting block

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "license": "MIT",
   "name": "prettier-lpc-vscode",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "engines": {
     "vscode": "^1.63.0"
   },

--- a/src/parser/lpcParser.ts
+++ b/src/parser/lpcParser.ts
@@ -2620,6 +2620,10 @@ export class LPCParser {
     nd.body = this.scanner.getTokenText();
     // remove the ending marker
     nd.body = nd.body.substring(0, nd.body.length - nd.marker.length);
+    nd.end = this.scanner.getTokenEnd();
+
+    this.eatWhitespace();
+    this.tryParseComment(nd);
 
     this.eatWhitespaceAndNewlines();
     return nd;

--- a/src/plugin/print/expression.ts
+++ b/src/plugin/print/expression.ts
@@ -61,6 +61,7 @@ export const printCallExpression: PrintNodeFunction<
   const printed = [path.call(printChildren, "callee")];
   const sym = Symbol("argGroup");
   printed.push("(");
+
   if (node.arguments && node.arguments.length > 0) {
     const arg0 = node.arguments[0];
     const argPrinted = join([",", line], path.map(printChildren, "arguments"));
@@ -72,7 +73,7 @@ export const printCallExpression: PrintNodeFunction<
     );
 
     const grouped = group([indent([softline, argPrinted])], { id: sym });
-    if (tryCondense && node.arguments.length == 1) {
+    if (tryCondense) { //} && node.arguments.length == 1) {
       // don't indent these
       printed.push(ifBreak(grouped, argPrinted));
     } else {
@@ -80,7 +81,8 @@ export const printCallExpression: PrintNodeFunction<
     }
   }
 
-  printed.push(ifBreak(softline, "", { groupId: sym }), ")");
+  printed.push(ifBreak(softline, "", { groupId: sym }));
+  printed.push(")");
 
   printed.push(printSuffixComments(node, path, options, printChildren));
 

--- a/src/plugin/print/literal.ts
+++ b/src/plugin/print/literal.ts
@@ -48,7 +48,9 @@ export const printStringLiteralBlock: PrintNodeFunction<
     trimmedMarker = trimmedMarker.substring(1);
   }
 
-  printed.push(dedentToRoot([body || "", hardline, trimmedMarker]),hardline);
+  printed.push(dedentToRoot([body || "", hardline, trimmedMarker]));
+  printed.push(printSuffixComments(node, path, options, printChildren));
+  printed.push(hardline);
 
   return printed;
 };

--- a/src/plugin/print/tests/__snapshots__/index.spec.ts.snap
+++ b/src/plugin/print/tests/__snapshots__/index.spec.ts.snap
@@ -1,6 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`prettier-lpc plugin fluffos text formatting shortcuts (@): textFormattingDouble 1`] = `
+exports[`prettier-lpc plugin FluffOS String Literal Blocks Text formatting shorcuts with suffix comment: textFormattingLiteralBlockWithSuffix 1`] = `
+"void test() {
+  set(@txt
+Here is 
+another block with
+no suffix comment
+txt
+  );
+
+  set("test", @txt
+Here is 
+another block with
+a suffix comment
+txt // '
+  );
+}"
+`;
+
+exports[`prettier-lpc plugin FluffOS String Literal Blocks fluffos text formatting shortcuts (@): textFormattingDouble 1`] = `
 "void test() {
   set_desc(@@TXT
 This is
@@ -10,13 +28,21 @@ TXT
 }"
 `;
 
-exports[`prettier-lpc plugin fluffos text formatting shortcuts (@): textFormattingSingle 1`] = `
+exports[`prettier-lpc plugin FluffOS String Literal Blocks fluffos text formatting shortcuts (@): textFormattingSingle 1`] = `
 "void test() {
   set_desc(@TXT
 This is
   a test
 TXT
   );
+}"
+`;
+
+exports[`prettier-lpc plugin FluffOS handles the spread operator (FluffOS): spread-op-function-and-callexp 1`] = `
+"mixed sum(mixed *numbers...) {
+  mixed number, result = 0;
+  fn(1, numbers...);
+  return result;
 }"
 `;
 
@@ -328,14 +354,6 @@ reset(arg) {
 `;
 
 exports[`prettier-lpc plugin handle string literals with escaped quotes: literal_strings_multiple_escapes 1`] = `"string s = "testing\\" 123\\\\";"`;
-
-exports[`prettier-lpc plugin handles the spread operator (FluffOS): spread-op-function-and-callexp 1`] = `
-"mixed sum(mixed *numbers...) {
-  mixed number, result = 0;
-  fn(1, numbers...);
-  return result;
-}"
-`;
 
 exports[`prettier-lpc plugin print inherit statements: inherit-basic 1`] = `
 "inherit "/path/file";

--- a/src/plugin/print/tests/index.spec.ts
+++ b/src/plugin/print/tests/index.spec.ts
@@ -11,6 +11,7 @@ import {
   textFormatCallExpInArray,
   textFormatCallExpInStringBinaryExp,
   textFormattingDouble,
+  textFormattingLiteralBlockWithSuffix,
   textFormattingSingle,
   textNestedParenBlocksWithLogicalExpr,
 } from "./inputs";
@@ -270,12 +271,6 @@ describe("prettier-lpc plugin", () => {
     formatted = format(`int *arr=filter(arr2,(:($1==1&&$1<10):));`);
     expect(formatted).toMatchInlineSnapshot(
       `"int *arr = filter(arr2, (: ($1 == 1 && $1 < 10) :));"`
-    );
-
-    // fluffos $() syntax
-    formatted = format(`int *arr=filter(arr2,(:$(var):));`);
-    expect(formatted).toMatchInlineSnapshot(
-      `"int *arr = filter(arr2, (: $(var) :));"`
     );
   });
 
@@ -559,13 +554,6 @@ describe("prettier-lpc plugin", () => {
     `);
   });
 
-  test("handles the spread operator (FluffOS)", () => {
-    let formatted = format(
-      `mixed sum(mixed *numbers...) { mixed number, result = 0; fn(1, numbers...); return result; }`
-    );
-    expect(formatted).toMatchSnapshot("spread-op-function-and-callexp");
-  });
-
   test("handle string literals with escaped quotes", () => {
     let formatted = format(`string s = "testing\\" 123";`);
     expect(formatted).toMatchInlineSnapshot(`"string s = "testing\\" 123";"`);
@@ -584,14 +572,6 @@ describe("prettier-lpc plugin", () => {
     expect(formatted).toMatchInlineSnapshot(
       `"string evaluate_path(string s);"`
     );
-  });
-
-  test("fluffos text formatting shortcuts (@)", () => {
-    let formatted = format(textFormattingSingle);
-    expect(formatted).toMatchSnapshot("textFormattingSingle");
-
-    formatted = format(textFormattingDouble);
-    expect(formatted).toMatchSnapshot("textFormattingDouble");
   });
 
   test("print inherit statements", () => {
@@ -615,5 +595,41 @@ describe("prettier-lpc plugin", () => {
       formatted = format(`test() { fn("a", -1); }`);
       expect(formatted).toMatchInlineSnapshot(`"test() { fn("a", -1); }"`);
     });
+  });
+
+  describe("FluffOS", () => {
+    describe("String Literal Blocks", () => {
+      test("fluffos text formatting shortcuts (@)", () => {
+        let formatted = format(textFormattingSingle);
+        expect(formatted).toMatchSnapshot("textFormattingSingle");
+
+        formatted = format(textFormattingDouble);
+        expect(formatted).toMatchSnapshot("textFormattingDouble");
+      });
+
+      test("Text formatting shorcuts with suffix comment", () => {
+        let formatted = format(textFormattingLiteralBlockWithSuffix);
+        expect(formatted).toMatchSnapshot(
+          "textFormattingLiteralBlockWithSuffix"
+        );
+      });
+    });
+
+    test("handles the spread operator (FluffOS)", () => {
+      let formatted = format(
+        `mixed sum(mixed *numbers...) { mixed number, result = 0; fn(1, numbers...); return result; }`
+      );
+      expect(formatted).toMatchSnapshot("spread-op-function-and-callexp");
+    });
+
+    test("Closures", () => {
+      // fluffos $() syntax
+      let formatted = format(`int *arr=filter(arr2,(:$(var):));`);
+      expect(formatted).toMatchInlineSnapshot(
+        `"int *arr = filter(arr2, (: $(var) :));"`
+      );
+    });
+
+    // end FluffOS
   });
 });

--- a/src/plugin/print/tests/inputs.ts
+++ b/src/plugin/print/tests/inputs.ts
@@ -136,6 +136,22 @@ TXT
   );
 }`
 
+export const textFormattingLiteralBlockWithSuffix = `void test() {      
+  set(@txt
+Here is 
+another block with
+no suffix comment
+txt
+);
+
+set("test", @txt
+Here is 
+another block with
+a suffix comment
+txt // '
+);
+}`
+
 export const textFormatCallExpInArray = `#define SOME_DEFINE "some define"
 
 void somefunc() {


### PR DESCRIPTION
Support suffix comments after FluffOS text formatting block.
Closes #18 