### PR TITLE
Text formatting shortcuts with duplicate marker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "license": "MIT",
   "name": "prettier-lpc-vscode",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "engines": {
     "vscode": "^1.63.0"
   },

--- a/src/parser/lpcParser.ts
+++ b/src/parser/lpcParser.ts
@@ -286,7 +286,7 @@ export class LPCParser {
     }
 
     throw this.parserError(
-      `unhandled token type ${token} [${this.scanner.getTokenText()}]:\nErr: ${this.scanner.getTokenError()}`
+      `unhandled token type ${token} [${this.scanner.getTokenText()}] @ ${this.scanner.getTokenOffset()}:\nErr: ${this.scanner.getTokenError()}`
     );
   }
 
@@ -2619,7 +2619,7 @@ export class LPCParser {
 
     nd.body = this.scanner.getTokenText();
     // remove the ending marker
-    nd.body = nd.body.substring(0, nd.body.length - nd.marker.length);
+    nd.body = nd.body.substring(0, nd.body.length - nd.marker.length - 1); // subtract 1 to account for newline before marker 
     nd.end = this.scanner.getTokenEnd();
 
     this.eatWhitespace();

--- a/src/plugin/print/expression.ts
+++ b/src/plugin/print/expression.ts
@@ -32,6 +32,7 @@ const {
   fill,
   indentIfBreak,
   ifBreak,
+  
   lineSuffix,
 } = builders;
 

--- a/src/plugin/print/literal.ts
+++ b/src/plugin/print/literal.ts
@@ -16,9 +16,12 @@ const {
   breakParent,
   softline,
   fill,
+  literallineWithoutBreakParent,
+  hardlineWithoutBreakParent,
   indentIfBreak,
   ifBreak,
   lineSuffix,
+
   dedentToRoot,
 } = builders;
 
@@ -39,14 +42,18 @@ export const printStringLiteralBlock: PrintNodeFunction<
   StringLiteralBlockNode
 > = (node, path, options, printChildren) => {
   const printed: Doc = [];
-  const { marker, body } = node;
+  let { marker, body } = node;
 
   printed.push(marker || "");
+  printed.push(hardlineWithoutBreakParent);
 
   let trimmedMarker = marker || "";
   while (trimmedMarker.startsWith("@")) {
     trimmedMarker = trimmedMarker.substring(1);
   }
+
+  // drop first newline.. hardlineWithoutBreakParent adds it for us
+  if (body && body.substring(0, 1) == "\n") body = body.substring(1);
 
   printed.push(dedentToRoot([body || "", hardline, trimmedMarker]));
   printed.push(printSuffixComments(node, path, options, printChildren));

--- a/src/plugin/print/tests/__snapshots__/index.spec.ts.snap
+++ b/src/plugin/print/tests/__snapshots__/index.spec.ts.snap
@@ -3,14 +3,14 @@
 exports[`prettier-lpc plugin FluffOS String Literal Blocks Text formatting shorcuts with suffix comment: textFormattingLiteralBlockWithSuffix 1`] = `
 "void test() {
   set(@txt
-Here is 
+  Here is 
 another block with
 no suffix comment
 txt
   );
 
   set("test", @txt
-Here is 
+  Here is 
 another block with
 a suffix comment
 txt // '
@@ -18,10 +18,23 @@ txt // '
 }"
 `;
 
+exports[`prettier-lpc plugin FluffOS String Literal Blocks Text formatting shortcuts with duplicate marker: textFormatStringBlockWithDuplicateMarker 1`] = `
+"test() {
+  set("long", @text
+  
+  The soft black and white pelt has been expertly cured to preserve the 
+texture and hairs of the panda's fur. Though the skin is quite beautiful,
+the animal itself must have been even more majestic.
+
+text
+  );
+}"
+`;
+
 exports[`prettier-lpc plugin FluffOS String Literal Blocks fluffos text formatting shortcuts (@): textFormattingDouble 1`] = `
 "void test() {
   set_desc(@@TXT
-This is
+  This is
   a tes
 TXT
   );
@@ -31,7 +44,7 @@ TXT
 exports[`prettier-lpc plugin FluffOS String Literal Blocks fluffos text formatting shortcuts (@): textFormattingSingle 1`] = `
 "void test() {
   set_desc(@TXT
-This is
+  This is
   a test
 TXT
   );

--- a/src/plugin/print/tests/index.spec.ts
+++ b/src/plugin/print/tests/index.spec.ts
@@ -10,6 +10,7 @@ import {
   spec_input_room,
   textFormatCallExpInArray,
   textFormatCallExpInStringBinaryExp,
+  textFormatStringBlockWithDuplicateMarker,
   textFormattingDouble,
   textFormattingLiteralBlockWithSuffix,
   textFormattingSingle,
@@ -104,7 +105,7 @@ describe("prettier-lpc plugin", () => {
     `);
     expect(formatted).toMatchSnapshot("array-with-multi-sfx-comments");
 
-    formatted=format(`test() { 
+    formatted = format(`test() { 
       items = ({
 #ifndef TEST
         1, 2,
@@ -627,6 +628,13 @@ describe("prettier-lpc plugin", () => {
         let formatted = format(textFormattingLiteralBlockWithSuffix);
         expect(formatted).toMatchSnapshot(
           "textFormattingLiteralBlockWithSuffix"
+        );
+      });
+
+      test("Text formatting shortcuts with duplicate marker", () => {
+        let formatted = format(textFormatStringBlockWithDuplicateMarker);
+        expect(formatted).toMatchSnapshot(
+          "textFormatStringBlockWithDuplicateMarker"
         );
       });
     });

--- a/src/plugin/print/tests/inputs.ts
+++ b/src/plugin/print/tests/inputs.ts
@@ -173,3 +173,14 @@ export const textNestedParenBlocksWithLogicalExpr = `test() {
     write("hi");
   }
 }`;
+
+export const textFormatStringBlockWithDuplicateMarker = `test() {
+  set("long", @text
+
+  The soft black and white pelt has been expertly cured to preserve the 
+texture and hairs of the panda's fur. Though the skin is quite beautiful,
+the animal itself must have been even more majestic.
+
+text
+ );
+}`;


### PR DESCRIPTION
Closes #18 where a text formatting shortcut would terminate too early if the marker text was found in another word.