### PR TITLE
Add support for array pairs

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "tabWidth": 2,
+  "useTabs": false  
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,8 +25,10 @@
             "runtimeExecutable": "${workspaceFolder}/build/extension.js",
             "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
             "outFiles": ["${workspaceFolder}/build/**/*.js"],
-            "preLaunchTask": "${defaultBuildTask}",
+            "preLaunchTask": "tsc: build - tsconfig.json",
             "autoAttachChildProcesses": true,			
+            "sourceMaps": true,
+            
           }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,5 @@
     }
   },
   "editor.tabSize": 2,
-  "cmake.configureOnOpen": false,
+  "cmake.configureOnOpen": false  
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
     }
   },
   "editor.tabSize": 2,
-  "cmake.configureOnOpen": false  
+  "cmake.configureOnOpen": false  ,
+  "editor.codeActionsOnSave": ["source.organizeImports"]
 }

--- a/README.md
+++ b/README.md
@@ -14,16 +14,36 @@ This plugin, like Prettier, is
 can be set via a [`.prettierrc` file](https://prettier.io/docs/en/configuration.html). In particular, the following
 options may be of interest to LPC developers:
 
-| API Option           | Default | Description                                                                        |
-| -------------------- | ------- | ---------------------------------------------------------------------------------- |
-| `printWidth`         |         | [Same option as in Prettier](https://prettier.io/docs/en/options.html#print-width) |
-| `tabWidth`           |         | [Same option as in Prettier](https://prettier.io/docs/en/options.html#tab-width)   |
-| `useTabs`            |         | [Same option as in Prettier](https://prettier.io/docs/en/options.html#tabs)        |
+| API Option           | Description                                                                        |
+| -------------------- | ---------------------------------------------------------------------------------- |
+| `printWidth`         | [Same option as in Prettier](https://prettier.io/docs/en/options.html#print-width) |
+| `tabWidth`           | [Same option as in Prettier](https://prettier.io/docs/en/options.html#tab-width)   |
+| `useTabs`            | [Same option as in Prettier](https://prettier.io/docs/en/options.html#tabs)        |
+| `pairVariables`      | See [Pair Arrays](#pair-arrays) |
 
 ## Multi-Line Objects
 
 For arrays and functions, this plugin follow's prettier's [multi-line objects rule](https://prettier.io/docs/en/rationale.html#multi-line-objects). For tips on how to control whether objects
 are collapsed to a single line, or not, see: https://prettier.io/docs/en/rationale.html#multi-line-objects
+
+## Pair Arrays
+In LDMud flavors of LPC there are often arrays that are treated as _pairs_. A common example of this is `dest_dir`. For example:
+```
+dest_dir = ({
+  "room/pub", "west",
+  "room/street1", "east",
+});
+```
+By default, this plugin is set to identify a list of common variable names for which arrays should be formatted in _pair_ mode as shown above. This list can be customized (or set to an empty array to completely disable this feature) by using the `pairVariables` setting.
+
+An array can also be forced into pair mode by utilizing the `@prettier-pair` hint:
+```
+// @prettier-pair
+string *pairs = ({
+  "key 1", "value 1",
+  "key 2", "value 2",
+});
+```
 
 ## Known Limitations
 The folowing languages features are not supported yet:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "license": "MIT",
   "name": "prettier-lpc-vscode",
-  "version": "0.0.64",
+  "version": "0.0.65",
   "engines": {
     "vscode": "^1.63.0"
   },
@@ -21,7 +21,8 @@
     "build": "npx tsc",
     "build:ext": "esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node",
     "vsce:package": "vsce package",
-    "vsce:publish": "vsce publish"
+    "vsce:publish": "vsce publish",
+    "watch": "tsc --watch --project ./"
   },
   "repository": {
     "type": "git",
@@ -44,7 +45,7 @@
     "onStartupFinished",
     "onCommand:prettier-lpc-vscode.format-document"
   ],
-  "main": "out/extension.js",
+  "main": "build/extension.js",
   "description": "",
   "devDependencies": {
     "@swc-node/jest": "1.5.3",
@@ -99,7 +100,17 @@
     ],
     "configuration": {
       "title": "Prettier LPC",
-      "properties": {                
+      "properties": {  
+        "Prettier-LPC.pairVariables": {
+          "type": "array",          
+          "default": [],
+          "description": "Array variables that are treated as pairs"
+        },
+        "Prettier-LPC.ignoreTabSettings": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Ignore user and workplace settings for `tabSize` and `insertSpaces` (uses `#Prettier-SQL.tabSizeOverride#` and `#Prettier-SQL.insertSpacesOverride#`)?"
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
       "properties": {  
         "Prettier-LPC.pairVariables": {
           "type": "array",          
-          "default": [],
+          "default": ["dest_dir","items","search_items","take_items","actions","sounds","search_fail","smells","look_items","contents","map_offset"],
           "description": "Array variables that are treated as pairs"
         },
         "Prettier-LPC.ignoreTabSettings": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "license": "MIT",
   "name": "prettier-lpc-vscode",
-  "version": "0.0.65",
+  "version": "0.0.66",
   "engines": {
     "vscode": "^1.63.0"
   },

--- a/src/nodeTypes/arrayExpression.ts
+++ b/src/nodeTypes/arrayExpression.ts
@@ -4,6 +4,7 @@ export class ArrayExpressionNode extends LPCNode {
   public type = "array";
   
   public elements: LPCNode[] = [];  
+  public printAsPairs=false;
 }
 
 export class IndexorExpressionNode extends LPCNode {

--- a/src/nodeTypes/assignmentExpression.ts
+++ b/src/nodeTypes/assignmentExpression.ts
@@ -1,9 +1,11 @@
 import { IdentifierNode } from "./identifier";
 import { LPCNode } from "./lpcNode";
 
+export const ASSIGN_EXP_TYPE: string = "assignment-exp";
+
 export class AssignmentExpressionNode extends LPCNode {
-  public override type: string | undefined = "assignment-exp";
+  public override type: string | undefined = ASSIGN_EXP_TYPE;
   public left: IdentifierNode | undefined;
-  public right: LPCNode | undefined;  
+  public right: LPCNode | undefined;
   public operator: string | undefined;
 }

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -6,7 +6,19 @@ import { lpcPrinters } from "./printer";
 export const AST_PARSER_NAME = "lpc";
 export const AST_FORMAT_NAME = "lpc";
 
-const DEFAULT_PAIR_VARS = ["dest_dir", "items"];
+const DEFAULT_PAIR_VARS = [
+  "dest_dir",
+  "items",
+  "search_items",
+  "take_items",
+  "actions",
+  "sounds",
+  "search_fail",
+  "smells",
+  "look_items",
+  "contents",
+  "map_offset",
+];
 
 export interface LPCOptions extends RequiredOptions, ParserOptions {
   //condenseSingleExpressionParams?: boolean;

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -6,7 +6,7 @@ import { lpcPrinters } from "./printer";
 export const AST_PARSER_NAME = "lpc";
 export const AST_FORMAT_NAME = "lpc";
 
-const DEFAULT_PAIR_VARS = [
+export const DEFAULT_PAIR_VARS = [
   "dest_dir",
   "items",
   "search_items",

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -6,11 +6,22 @@ import { lpcPrinters } from "./printer";
 export const AST_PARSER_NAME = "lpc";
 export const AST_FORMAT_NAME = "lpc";
 
+const DEFAULT_PAIR_VARS = ["dest_dir", "items"];
+
 export interface LPCOptions extends RequiredOptions, ParserOptions {
-  //condenseSingleExpressionParams?: boolean;  
+  //condenseSingleExpressionParams?: boolean;
+  pairVariables?: string[];
 }
 
 export const options = {
+  pairVariables: {
+    since: "0.0.65",
+    category: "LPC",
+    type: "string",
+    array: true,
+    default: [{ value: DEFAULT_PAIR_VARS }],
+    describe: "Array variables to print as pairs (two elements per line)",
+  } as SupportOption,
   // condenseSingleExpressionParams: {
   //   since: "0.0.1",
   //   category: "LPC",
@@ -18,11 +29,12 @@ export const options = {
   //   default: true,
   //   description:
   //     "Put array or mapping opening brackets on the same line as call-exp parens",
-  // } as SupportOption,  
+  // } as SupportOption,
 };
 
 export const defaultOptions: Partial<LPCOptions> = {
-  tabWidth: 2,  
+  tabWidth: 2,
+  pairVariables: DEFAULT_PAIR_VARS,
 };
 
 export const languages: Plugin["languages"] = [

--- a/src/plugin/print/array.ts
+++ b/src/plugin/print/array.ts
@@ -211,7 +211,9 @@ function shouldPrintAsPair(path: AstPath<LPCNode>, options: LPCOptions) {
 
   // not a variable that is always treated as a pair,
   // check for a @prettier-pair hint
-  if (!isMatch) {
+  if (isMatch) {
+    return true;
+  } else if (!isMatch) {
     const comment = getPreviousComment(path);
     if (comment?.body?.includes("@prettier-pair")) {
       return true;

--- a/src/plugin/print/comment.ts
+++ b/src/plugin/print/comment.ts
@@ -1,9 +1,10 @@
-import { Doc } from "prettier";
+import { AstPath, Doc } from "prettier";
 import { builders } from "prettier/doc";
-import { InlineCommentNode, CommentBlockNode } from "../../nodeTypes/comment";
+import { InlineCommentNode, CommentBlockNode, CommentNode } from "../../nodeTypes/comment";
 import { LPCNode } from "../../nodeTypes/lpcNode";
 import { last } from "../../utils/arrays";
 import { PrintNodeFunction } from "./shared";
+import { Comment } from "vscode";
 
 const {
   group,
@@ -103,3 +104,18 @@ export const printSuffixComments: PrintNodeFunction<LPCNode, LPCNode> = (
     ];
   else return [];
 };
+
+export function getPreviousComment(path: AstPath<LPCNode>): CommentNode|undefined {
+  
+  const m = path.match((nd,nm,num)=>{
+    if (nd.type=="commentblock" || (!!num && num==0)) return false;
+    else if (!!num && num > 0) {
+      debugger;
+    }
+    return true;    
+  }, (nd,nm,num)=>{
+    return (nd.type=="codeblock");
+  });
+ 
+  return undefined;
+}

--- a/src/plugin/print/expression.ts
+++ b/src/plugin/print/expression.ts
@@ -14,9 +14,11 @@ import { LPCNode } from "../../nodeTypes/lpcNode";
 import { MemberExpressionNode } from "../../nodeTypes/memberExpression";
 import { UnaryPrefixExpressionNode } from "../../nodeTypes/unaryPrefixExpression";
 import { VariableDeclarationNode } from "../../nodeTypes/variableDeclaration";
-import { pushIfVal } from "../../utils/arrays";
+import { pushIfVal, shouldPrintPairs } from "../../utils/arrays";
 import { printSuffixComments } from "./comment";
 import { isInParen, needsSemi, PrintNodeFunction } from "./shared";
+import { printArray } from "./array";
+import { ArrayExpressionNode } from "../../nodeTypes/arrayExpression";
 
 const {
   group,
@@ -32,7 +34,7 @@ const {
   fill,
   indentIfBreak,
   ifBreak,
-  
+
   lineSuffix,
 } = builders;
 
@@ -74,7 +76,8 @@ export const printCallExpression: PrintNodeFunction<
     );
 
     const grouped = group([indent([softline, argPrinted])], { id: sym });
-    if (tryCondense) { //} && node.arguments.length == 1) {
+    if (tryCondense) {
+      //} && node.arguments.length == 1) {
       // don't indent these
       printed.push(ifBreak(grouped, argPrinted));
     } else {
@@ -109,9 +112,20 @@ export const printAssignmentExpression: PrintNodeFunction<
   if (node.operator != "++" && node.operator != "--") printed.push(" ");
   printed.push(node.operator || "");
 
+  let printPairs = false;
+  switch (node.left?.name) {
+    case "dest_dir":
+    case "items":
+      printPairs = true;
+      break;
+  }
+
   if (node.right) {
     const shouldIndent =
       node.right?.type != "array" && node.right?.type != "mapping";
+
+    shouldPrintPairs(node.left?.name, options, node.right);
+
     const rightPrinted = path.call(printChildren, "right");
 
     if (shouldIndent) {

--- a/src/plugin/print/expression.ts
+++ b/src/plugin/print/expression.ts
@@ -14,7 +14,7 @@ import { LPCNode } from "../../nodeTypes/lpcNode";
 import { MemberExpressionNode } from "../../nodeTypes/memberExpression";
 import { UnaryPrefixExpressionNode } from "../../nodeTypes/unaryPrefixExpression";
 import { VariableDeclarationNode } from "../../nodeTypes/variableDeclaration";
-import { pushIfVal, shouldPrintPairs } from "../../utils/arrays";
+import { pushIfVal } from "../../utils/arrays";
 import { printSuffixComments } from "./comment";
 import { isInParen, needsSemi, PrintNodeFunction } from "./shared";
 import { printArray } from "./array";
@@ -123,8 +123,6 @@ export const printAssignmentExpression: PrintNodeFunction<
   if (node.right) {
     const shouldIndent =
       node.right?.type != "array" && node.right?.type != "mapping";
-
-    shouldPrintPairs(node.left?.name, options, node.right);
 
     const rightPrinted = path.call(printChildren, "right");
 

--- a/src/plugin/print/tests/__snapshots__/index.spec.ts.snap
+++ b/src/plugin/print/tests/__snapshots__/index.spec.ts.snap
@@ -65,15 +65,14 @@ exports[`prettier-lpc plugin FluffOS handles the spread operator (FluffOS): spre
 `;
 
 exports[`prettier-lpc plugin format arrays: array-condensed 1`] = `
-"test() { items = ({({"gates", "steel gates"}), "Strong metal gates."}); }
+"test() { items = ({({"gates", "steel gates"}), "Strong metal gates.",}); }
 "
 `;
 
 exports[`prettier-lpc plugin format arrays: array-inner-condensed 1`] = `
 "test() {
   items = ({
-    ({"gates", "steel gates"}),
-    "Strong metal gates.",
+    ({"gates", "steel gates"}), "Strong metal gates.",
   });
 }
 "
@@ -86,7 +85,7 @@ exports[`prettier-lpc plugin format arrays: array-none-condensed 1`] = `
       "gates",
       "steel gates",
     }),
-    "Strong metal gates.",
+      "Strong metal gates.",
   });
 }
 "
@@ -109,8 +108,7 @@ exports[`prettier-lpc plugin format arrays: array-with-multi-sfx-comments 1`] = 
 "
 test() {
   items = ({
-    ({"gates", "steel gates"}),
-    "Strong metal gates.", // inner sfx
+    ({"gates", "steel gates"}), "Strong metal gates.", // inner sfx
   }); // sfx
   // post
 }
@@ -120,7 +118,7 @@ test() {
 exports[`prettier-lpc plugin format arrays: array-with-sfx-comment 1`] = `
 "
 test() {
-  items = ({({"gates", "steel gates"}), "Strong metal gates."}); // sfx
+  items = ({({"gates", "steel gates"}), "Strong metal gates.",}); // sfx
 }
 "
 `;
@@ -411,15 +409,12 @@ reset(arg) {
       "on for several lines
 ";
     items = ({
-      ({"table", "small table", "wood table"}),
-      "A table made of wood",
-      ({"bench", "wood bench"}),
-      "A bench made of wood",
+      ({"table", "small table", "wood table"}), "A table made of wood",
+      ({"bench", "wood bench"}), "A bench made of wood",
     });
 
     dest_dir = ({
-      BASE + "/northroom",
-      "north",
+      BASE + "/northroom", "north",
     });
   }
 
@@ -462,5 +457,26 @@ test() { write("test"); }
 exports[`prettier-lpc plugin inherit statements print inherit statements: inherit-parenblock 1`] = `
 "inherit (__DIR__ + "file");
 test() { write("test"); }
+"
+`;
+
+exports[`prettier-lpc plugin pair arrays format pair arrays based on hint: array-pair-varname 1`] = `
+"test() {
+  // @prettier-pair
+  not_dest_dir = ({
+    "room1", "north",
+    "room2", "south",
+  });
+}
+"
+`;
+
+exports[`prettier-lpc plugin pair arrays format pair arrays based on var name: array-pair-varname 1`] = `
+"test() {
+  dest_dir = ({
+    "room1", "north",
+    "room2", "south",
+  });
+}
 "
 `;

--- a/src/plugin/print/tests/__snapshots__/index.spec.ts.snap
+++ b/src/plugin/print/tests/__snapshots__/index.spec.ts.snap
@@ -15,7 +15,8 @@ another block with
 a suffix comment
 txt // '
   );
-}"
+}
+"
 `;
 
 exports[`prettier-lpc plugin FluffOS String Literal Blocks Text formatting shortcuts with duplicate marker: textFormatStringBlockWithDuplicateMarker 1`] = `
@@ -28,7 +29,8 @@ the animal itself must have been even more majestic.
 
 text
   );
-}"
+}
+"
 `;
 
 exports[`prettier-lpc plugin FluffOS String Literal Blocks fluffos text formatting shortcuts (@): textFormattingDouble 1`] = `
@@ -38,7 +40,8 @@ exports[`prettier-lpc plugin FluffOS String Literal Blocks fluffos text formatti
   a tes
 TXT
   );
-}"
+}
+"
 `;
 
 exports[`prettier-lpc plugin FluffOS String Literal Blocks fluffos text formatting shortcuts (@): textFormattingSingle 1`] = `
@@ -48,7 +51,8 @@ exports[`prettier-lpc plugin FluffOS String Literal Blocks fluffos text formatti
   a test
 TXT
   );
-}"
+}
+"
 `;
 
 exports[`prettier-lpc plugin FluffOS handles the spread operator (FluffOS): spread-op-function-and-callexp 1`] = `
@@ -56,10 +60,14 @@ exports[`prettier-lpc plugin FluffOS handles the spread operator (FluffOS): spre
   mixed number, result = 0;
   fn(1, numbers...);
   return result;
-}"
+}
+"
 `;
 
-exports[`prettier-lpc plugin format arrays: array-condensed 1`] = `"test() { items = ({({"gates", "steel gates"}), "Strong metal gates."}); }"`;
+exports[`prettier-lpc plugin format arrays: array-condensed 1`] = `
+"test() { items = ({({"gates", "steel gates"}), "Strong metal gates."}); }
+"
+`;
 
 exports[`prettier-lpc plugin format arrays: array-inner-condensed 1`] = `
 "test() {
@@ -67,7 +75,8 @@ exports[`prettier-lpc plugin format arrays: array-inner-condensed 1`] = `
     ({"gates", "steel gates"}),
     "Strong metal gates.",
   });
-}"
+}
+"
 `;
 
 exports[`prettier-lpc plugin format arrays: array-none-condensed 1`] = `
@@ -79,7 +88,8 @@ exports[`prettier-lpc plugin format arrays: array-none-condensed 1`] = `
     }),
     "Strong metal gates.",
   });
-}"
+}
+"
 `;
 
 exports[`prettier-lpc plugin format arrays: array-with-inline-directives 1`] = `
@@ -91,7 +101,8 @@ exports[`prettier-lpc plugin format arrays: array-with-inline-directives 1`] = `
     3,
 #endif
   });
-}"
+}
+"
 `;
 
 exports[`prettier-lpc plugin format arrays: array-with-multi-sfx-comments 1`] = `
@@ -102,20 +113,23 @@ test() {
     "Strong metal gates.", // inner sfx
   }); // sfx
   // post
-}"
+}
+"
 `;
 
 exports[`prettier-lpc plugin format arrays: array-with-sfx-comment 1`] = `
 "
 test() {
   items = ({({"gates", "steel gates"}), "Strong metal gates."}); // sfx
-}"
+}
+"
 `;
 
 exports[`prettier-lpc plugin format arrow operators: arrow-newline-after 1`] = `
 "test() {
   "/obj/master"->query_player_exists();
-}"
+}
+"
 `;
 
 exports[`prettier-lpc plugin format assignment expressions: assign_exp_suffix_comment 1`] = `
@@ -123,12 +137,14 @@ exports[`prettier-lpc plugin format assignment expressions: assign_exp_suffix_co
   exits = room->exits();
   if (exits == -1) arr = ([]); // erase all exits
   else if (stringp(exits)) arr -= ([exits]);
-}"
+}
+"
 `;
 
 exports[`prettier-lpc plugin format assignment expressions: assignment_inside_array 1`] = `
 "int i = 0;
-test() { indices = ({i, index++}); }"
+test() { indices = ({i, index++}); }
+"
 `;
 
 exports[`prettier-lpc plugin format binary expressions: call-exp-inside-binary-string-exp 1`] = `
@@ -136,7 +152,8 @@ exports[`prettier-lpc plugin format binary expressions: call-exp-inside-binary-s
   string name = query_name();
   return name + " was defeated by " + "/daemons/time_d"->query_time() + ".
 ";
-}"
+}
+"
 `;
 
 exports[`prettier-lpc plugin format call-exp inside arrays: call-exp-in-array 1`] = `
@@ -145,7 +162,8 @@ exports[`prettier-lpc plugin format call-exp inside arrays: call-exp-in-array 1`
 void somefunc() {
   string *words;
   words = ({SOME_DEFINE, lower_case(SOME_DEFINE), upper_case(SOME_DEFINE)});
-}"
+}
+"
 `;
 
 exports[`prettier-lpc plugin format closures: closure-greaterthan-this_player 1`] = `
@@ -153,19 +171,27 @@ exports[`prettier-lpc plugin format closures: closure-greaterthan-this_player 1`
   object *hash = ({});
   hash = sort_array(hash, #'>);
   hash = filter(hash, #'this_player);
-}"
+}
+"
 `;
 
 exports[`prettier-lpc plugin format foreach loops: foreach-collapsed 1`] = `
 "test() {
   string exitKey;
   foreach (exitKey : all_exits) { write(exitKey); }
-}"
+}
+"
 `;
 
-exports[`prettier-lpc plugin format foreach loops: foreach-multi-var 1`] = `"test() { foreach (x, y : a) { z = b[x]; } }"`;
+exports[`prettier-lpc plugin format foreach loops: foreach-multi-var 1`] = `
+"test() { foreach (x, y : a) { z = b[x]; } }
+"
+`;
 
-exports[`prettier-lpc plugin format foreach loops: foreach-multi-var-keep-in 1`] = `"test() { foreach (x, y in a) { z = b[x]; } }"`;
+exports[`prettier-lpc plugin format foreach loops: foreach-multi-var-keep-in 1`] = `
+"test() { foreach (x, y in a) { z = b[x]; } }
+"
+`;
 
 exports[`prettier-lpc plugin format foreach loops: foreach-multiline 1`] = `
 "test() {
@@ -174,12 +200,14 @@ exports[`prettier-lpc plugin format foreach loops: foreach-multiline 1`] = `
     write(exitKey);
     i++;
   }
-}"
+}
+"
 `;
 
 exports[`prettier-lpc plugin format foreach loops: foreach-range-collapsed 1`] = `
 "test() { foreach (i : 1 .. 6) printf("%d
-", i); }"
+", i); }
+"
 `;
 
 exports[`prettier-lpc plugin format foreach loops: foreach-range-multiline 1`] = `
@@ -189,14 +217,16 @@ exports[`prettier-lpc plugin format foreach loops: foreach-range-multiline 1`] =
 ", i);
     j++;
   }
-}"
+}
+"
 `;
 
 exports[`prettier-lpc plugin format functions: function-stub-with-newline-comments 1`] = `
 "int gmcp_send_map();
 int gmcp_send_map_config();
 
-/* Should not move the coment up after the semi */"
+/* Should not move the coment up after the semi */
+"
 `;
 
 exports[`prettier-lpc plugin format functions: function-stubs 1`] = `
@@ -204,7 +234,8 @@ exports[`prettier-lpc plugin format functions: function-stubs 1`] = `
 public int query_level();
 public void set_level(int level);
 public int query_next_level();
-public int query_level() { return level; }"
+public int query_level() { return level; }
+"
 `;
 
 exports[`prettier-lpc plugin format literal strings: literal_consecutive_strings 1`] = `
@@ -222,23 +253,27 @@ exports[`prettier-lpc plugin format literal strings: literal_consecutive_strings
     "this is line 2.
 " +
     "this is line 3.";
-}"
+}
+"
 `;
 
 exports[`prettier-lpc plugin format macros: define-macro-multieline-withslash 1`] = `
 "#define TXT \\
   "String here with embedded \\n slash that is pretty long and should wrap to the next"\\
-  + "line. Another line here. Don't combine this line because it is long too.""
+  + "line. Another line here. Don't combine this line because it is long too."
+"
 `;
 
 exports[`prettier-lpc plugin format macros: define-macro-multiline 1`] = `
 "#define W2(s) \\
-  trim("local/really really really long string really really really really long/util")->       wrap(({ a, s }))"
+  trim("local/really really really long string really really really really long/util")->       wrap(({ a, s }))
+"
 `;
 
 exports[`prettier-lpc plugin format macros: define-macro-with-wrap 1`] = `
 "#define WRAP(str) \\
-  trim("really really really really long string"->word_wrap(str), 2)"
+  trim("really really really really long string"->word_wrap(str), 2)
+"
 `;
 
 exports[`prettier-lpc plugin format parens: nested-parens-with-logical-exp 1`] = `
@@ -246,7 +281,8 @@ exports[`prettier-lpc plugin format parens: nested-parens-with-logical-exp 1`] =
   if ((ob = present("id", TP)) && (str == "to" || str == "from")) {
     write("hi");
   }
-}"
+}
+"
 `;
 
 exports[`prettier-lpc plugin format ternary expressions: mapping_with_ternary_value 1`] = `
@@ -276,20 +312,23 @@ public varargs int send_config(object player) {
 
   object p = player ? player : this_player();
   return p->send(PKG, pkg);
-}"
+}
+"
 `;
 
 exports[`prettier-lpc plugin format ternary expressions: ternary_arith_op_inside 1`] = `
 "private int round(float n) {
   int i = (int)(n < 0 ? n - 0.5 : n + 0.5);
   return i;
-}"
+}
+"
 `;
 
 exports[`prettier-lpc plugin format ternary expressions: ternary-after-binary 1`] = `
 "test() {
   str = (str[0] == '/' ? "/" + implode(path, "/") : implode(path, "/"));
-}"
+}
+"
 `;
 
 exports[`prettier-lpc plugin format ternary expressions: ternary-with-lit-binary-op 1`] = `
@@ -299,7 +338,8 @@ exports[`prettier-lpc plugin format ternary expressions: ternary-with-lit-binary
     " looks at " + (gender == 1 ? "him" : "her") +
     "."
   );
-}"
+}
+"
 `;
 
 exports[`prettier-lpc plugin formats for loops: for_loop_various 1`] = `
@@ -314,12 +354,19 @@ exports[`prettier-lpc plugin formats for loops: for_loop_various 1`] = `
 exports[`prettier-lpc plugin formats for loops: for-loop_multi_expression 1`] = `
 "test() {
   for (i = 0, j = sizeof(keys); i < j; i++, j--) { string key = keys[i]; }
-}"
+}
+"
 `;
 
-exports[`prettier-lpc plugin formats for loops: loop-break-shouldhave-semi 1`] = `"void test() { while (true) { if (1 == 1) break; } }"`;
+exports[`prettier-lpc plugin formats for loops: loop-break-shouldhave-semi 1`] = `
+"void test() { while (true) { if (1 == 1) break; } }
+"
+`;
 
-exports[`prettier-lpc plugin formats for loops: loop-continue-shouldhave-semi 1`] = `"void test() { while (true) { if (1 == 1) continue; } }"`;
+exports[`prettier-lpc plugin formats for loops: loop-continue-shouldhave-semi 1`] = `
+"void test() { while (true) { if (1 == 1) continue; } }
+"
+`;
 
 exports[`prettier-lpc plugin formats if statements: if_condense_test 1`] = `
 "test() {
@@ -333,14 +380,16 @@ exports[`prettier-lpc plugin formats if statements: if_condense_test 1`] = `
     move_player("sky");
     return 1;
   } else return 0;
-}"
+}
+"
 `;
 
 exports[`prettier-lpc plugin formatter should handle missing semi's: missing_semi_comma_instead 1`] = `
 "test() {
   short = "short name";
   long = "long" + "desc";
-}"
+}
+"
 `;
 
 exports[`prettier-lpc plugin general formatting: spec_input_room 1`] = `
@@ -381,29 +430,37 @@ reset(arg) {
     monster->set_hp(200);
     move_object(monster, this_object());
   }
-}"
+}
+"
 `;
 
-exports[`prettier-lpc plugin handle string literals with escaped quotes: literal_strings_multiple_escapes 1`] = `"string s = "testing\\" 123\\\\";"`;
+exports[`prettier-lpc plugin handle string literals with escaped quotes: literal_strings_multiple_escapes 1`] = `
+"string s = "testing\\" 123\\\\";
+"
+`;
 
 exports[`prettier-lpc plugin inherit statements parse inherit statements with just a define: inherit-define 1`] = `
 "
 #define D "test"
 inherit DEFINE;
-test() {  }"
+test() {  }
+"
 `;
 
 exports[`prettier-lpc plugin inherit statements print inherit statements: inherit-basic 1`] = `
 "inherit "/path/file";
-test() { write("test"); }"
+test() { write("test"); }
+"
 `;
 
 exports[`prettier-lpc plugin inherit statements print inherit statements: inherit-implied-concat 1`] = `
 "inherit __DIR__ "file" ".c";
-test() { write("test"); }"
+test() { write("test"); }
+"
 `;
 
 exports[`prettier-lpc plugin inherit statements print inherit statements: inherit-parenblock 1`] = `
 "inherit (__DIR__ + "file");
-test() { write("test"); }"
+test() { write("test"); }
+"
 `;

--- a/src/plugin/print/tests/index.spec.ts
+++ b/src/plugin/print/tests/index.spec.ts
@@ -38,34 +38,41 @@ describe("prettier-lpc plugin", () => {
 
   test("formats short functions", () => {
     let formatted = format(`string set_s(string s){return foo=s;}`);
-    expect(formatted).toMatchInlineSnapshot(
-      `"string set_s(string s) { return foo = s; }"`
-    );
+    expect(formatted).toMatchInlineSnapshot(`
+      "string set_s(string s) { return foo = s; }
+      "
+    `);
 
     formatted = format(`query_s ( ) {return s;}`);
-    expect(formatted).toMatchInlineSnapshot(`"query_s() { return s; }"`);
+    expect(formatted).toMatchInlineSnapshot(`
+      "query_s() { return s; }
+      "
+    `);
 
     formatted = format(`test() { int i=0; return 1; }`);
     expect(formatted).toMatchInlineSnapshot(`
       "test() {
         int i = 0;
         return 1;
-      }"
+      }
+      "
     `);
   });
 
   test("format array typecasts", () => {
     let formatted = format(`string *dirs = (string *) env->query_dest_dir();`);
-    expect(formatted).toMatchInlineSnapshot(
-      `"string *dirs = (string*)env->query_dest_dir();"`
-    );
+    expect(formatted).toMatchInlineSnapshot(`
+      "string *dirs = (string*)env->query_dest_dir();
+      "
+    `);
 
     formatted = format(
       `string * dirs = obj->fn( (string *) env->query_dest_dir() );`
     );
-    expect(formatted).toMatchInlineSnapshot(
-      `"string *dirs = obj->fn((string*)env->query_dest_dir());"`
-    );
+    expect(formatted).toMatchInlineSnapshot(`
+      "string *dirs = obj->fn((string*)env->query_dest_dir());
+      "
+    `);
   });
 
   test("format arrays", () => {
@@ -123,9 +130,10 @@ describe("prettier-lpc plugin", () => {
 
   test("format args passed byref", () => {
     let formatted = format(`test(string &d) { d[0] += 32; }`);
-    expect(formatted).toMatchInlineSnapshot(
-      `"test(string &d) { d[0] += 32; }"`
-    );
+    expect(formatted).toMatchInlineSnapshot(`
+      "test(string &d) { d[0] += 32; }
+      "
+    `);
   });
 
   test("format parens", () => {
@@ -133,9 +141,10 @@ describe("prettier-lpc plugin", () => {
     let formatted = format(
       `void test() { obj->set_weight(1 + random(avail_weight-1))     }`
     );
-    expect(formatted).toMatchInlineSnapshot(
-      `"void test() { obj->set_weight(1 + random(avail_weight - 1)); }"`
-    );
+    expect(formatted).toMatchInlineSnapshot(`
+      "void test() { obj->set_weight(1 + random(avail_weight - 1)); }
+      "
+    `);
 
     formatted = format(textNestedParenBlocksWithLogicalExpr);
     expect(formatted).toMatchSnapshot("nested-parens-with-logical-exp");
@@ -146,25 +155,28 @@ describe("prettier-lpc plugin", () => {
     let formatted = format(
       `printf("Foo is %s\\n", test=="bar" ? "bar" : "notbar");`
     );
-    expect(formatted).toMatchInlineSnapshot(
-      `"printf("Foo is %s\\n", test == "bar" ? "bar" : "notbar");"`
-    );
+    expect(formatted).toMatchInlineSnapshot(`
+      "printf("Foo is %s\\n", test == "bar" ? "bar" : "notbar");
+      "
+    `);
 
     // with paren
     formatted = format(
       `printf("Foo is %s\\n", (test=="bar") ? "bar" : "notbar");`
     );
-    expect(formatted).toMatchInlineSnapshot(
-      `"printf("Foo is %s\\n", (test == "bar") ? "bar" : "notbar");"`
-    );
+    expect(formatted).toMatchInlineSnapshot(`
+      "printf("Foo is %s\\n", (test == "bar") ? "bar" : "notbar");
+      "
+    `);
 
     // arith op inside ternary
     formatted = format(
       `private int round(float n) { return (int)(n < 0 ? n - 0.5 : n + 0.5); }`
     );
-    expect(formatted).toMatchInlineSnapshot(
-      `"private int round(float n) { return (int)(n < 0 ? n - 0.5 : n + 0.5); }"`
-    );
+    expect(formatted).toMatchInlineSnapshot(`
+      "private int round(float n) { return (int)(n < 0 ? n - 0.5 : n + 0.5); }
+      "
+    `);
 
     formatted = format(
       `private int round(float n) { int i=(int)(n < 0 ? n - 0.5 : n + 0.5); return i; }`
@@ -185,16 +197,17 @@ describe("prettier-lpc plugin", () => {
 `
     );
     expect(formatted).toMatchInlineSnapshot(`
-          "test() {
-            if (!a && !ob->b()) return "foo";
-            else
-              return
-                sprintf(
-                  "bar %s",
-                  ob->test() && ob2->test() ? "bar" : ob->bar() ? "baz" : "baz2"
-                );
-          }"
-        `);
+      "test() {
+        if (!a && !ob->b()) return "foo";
+        else
+          return
+            sprintf(
+              "bar %s",
+              ob->test() && ob2->test() ? "bar" : ob->bar() ? "baz" : "baz2"
+            );
+      }
+      "
+    `);
 
     formatted = format(mapping_with_ternary_value);
     expect(formatted).toMatchSnapshot("mapping_with_ternary_value");
@@ -219,7 +232,8 @@ describe("prettier-lpc plugin", () => {
         if (a != 0 && (b == 0 || c >= MIN)) {
           return 1;
         }
-      }"
+      }
+      "
     `);
 
     formatted = format(textFormatCallExpInStringBinaryExp);
@@ -228,16 +242,18 @@ describe("prettier-lpc plugin", () => {
     formatted = format(
       `int rounded = (((cnt + 5) / 10) * 10); // cheap rounding to nearest 10`
     );
-    expect(formatted).toMatchInlineSnapshot(
-      `"int rounded = (((cnt + 5) / 10) * 10); // cheap rounding to nearest 10"`
-    );
+    expect(formatted).toMatchInlineSnapshot(`
+      "int rounded = (((cnt + 5) / 10) * 10); // cheap rounding to nearest 10
+      "
+    `);
   });
 
   test("format logical expression", () => {
     let formatted = format(`test(str) {return str == "NO" || str == "TWO";}`);
-    expect(formatted).toMatchInlineSnapshot(
-      `"test(str) { return str == "NO" || str == "TWO"; }"`
-    );
+    expect(formatted).toMatchInlineSnapshot(`
+      "test(str) { return str == "NO" || str == "TWO"; }
+      "
+    `);
 
     formatted = format(
       `test() { if (str == "a" && found2 & !taken) { write("You find nothing."); return 1; } }`
@@ -248,7 +264,8 @@ describe("prettier-lpc plugin", () => {
           write("You find nothing.");
           return 1;
         }
-      }"
+      }
+      "
     `);
   });
 
@@ -257,14 +274,15 @@ describe("prettier-lpc plugin", () => {
       list = filter_array(info(), lambda(({ 'test }), ({ #'!=, ({ #'[, 'isValid, NAME }), \"NONAME\" }) )); 
     }`);
     expect(formatted).toMatchInlineSnapshot(`
-          "test() {
-            list =
-              filter_array(
-                info(),
-                lambda(({'test}), ({#'!=, ({#'[, 'isValid, NAME}), "NONAME"}))
-              );
-          }"
-        `);
+      "test() {
+        list =
+          filter_array(
+            info(),
+            lambda(({'test}), ({#'!=, ({#'[, 'isValid, NAME}), "NONAME"}))
+          );
+      }
+      "
+    `);
   });
 
   test("format closures", () => {
@@ -276,20 +294,23 @@ describe("prettier-lpc plugin", () => {
     formatted = format(
       `object *a = filter(all_inventory(room), (: $1->id("something") :));`
     );
-    expect(formatted).toMatchInlineSnapshot(
-      `"object *a = filter(all_inventory(room), (: $1->id("something") :));"`
-    );
+    expect(formatted).toMatchInlineSnapshot(`
+      "object *a = filter(all_inventory(room), (: $1->id("something") :));
+      "
+    `);
 
     // whitespace between ( and :
     formatted = format(`int *arr=filter(arr2,( :($1==1&&$1<10):));`);
-    expect(formatted).toMatchInlineSnapshot(
-      `"int *arr = filter(arr2, (: ($1 == 1 && $1 < 10) :));"`
-    );
+    expect(formatted).toMatchInlineSnapshot(`
+      "int *arr = filter(arr2, (: ($1 == 1 && $1 < 10) :));
+      "
+    `);
 
     formatted = format(`int *arr=filter(arr2,(:($1==1&&$1<10):));`);
-    expect(formatted).toMatchInlineSnapshot(
-      `"int *arr = filter(arr2, (: ($1 == 1 && $1 < 10) :));"`
-    );
+    expect(formatted).toMatchInlineSnapshot(`
+      "int *arr = filter(arr2, (: ($1 == 1 && $1 < 10) :));
+      "
+    `);
   });
 
   test("format variable declarations", () => {
@@ -299,15 +320,17 @@ describe("prettier-lpc plugin", () => {
     `);
 
     expect(formatted).toMatchInlineSnapshot(`
-          "string *arr, /* OPTIONAL: Array of stuff */
-                 code; /* test comment */"
-        `);
+      "string *arr, /* OPTIONAL: Array of stuff */
+             code; /* test comment */
+      "
+    `);
 
     // multi-decl var
     formatted = format(`string *arr, code="", test=0, s;`);
-    expect(formatted).toMatchInlineSnapshot(
-      `"string *arr, code = "", test = 0, s;"`
-    );
+    expect(formatted).toMatchInlineSnapshot(`
+      "string *arr, code = "", test = 0, s;
+      "
+    `);
 
     // multilpe types of var decls
     formatted = format(`string s; mixed m; int i=0; mapping mp;`);
@@ -315,7 +338,8 @@ describe("prettier-lpc plugin", () => {
       "string s;
       mixed m;
       int i = 0;
-      mapping mp;"
+      mapping mp;
+      "
     `);
 
     // var decl inside function
@@ -324,7 +348,8 @@ describe("prettier-lpc plugin", () => {
       "test() {
         int i, j;
         string s = "";
-      }"
+      }
+      "
     `);
   });
 
@@ -333,18 +358,20 @@ describe("prettier-lpc plugin", () => {
     struct coords { int x; int y; };`);
 
     expect(formatted).toMatchInlineSnapshot(`
-          "// this struct should be on a single line
-          struct coords { int x; int y; };"
-        `);
+      "// this struct should be on a single line
+      struct coords { int x; int y; };
+      "
+    `);
   });
 
   test("format macros", () => {
     let formatted = format(
       `#define WRAP(str)  trim("test"->word_wrap(str), 2)`
     );
-    expect(formatted).toMatchInlineSnapshot(
-      `"#define WRAP(str) trim("test"->word_wrap(str), 2)"`
-    );
+    expect(formatted).toMatchInlineSnapshot(`
+      "#define WRAP(str) trim("test"->word_wrap(str), 2)
+      "
+    `);
 
     formatted = format(
       `#define WRAP(str)  trim("really really really really long string"->word_wrap(str), 2)`,
@@ -375,35 +402,47 @@ describe("prettier-lpc plugin", () => {
 
     // arrow after obj
     formatted = format(`string s = obj->test();`);
-    expect(formatted).toMatchInlineSnapshot(`"string s = obj->test();"`);
+    expect(formatted).toMatchInlineSnapshot(`
+      "string s = obj->test();
+      "
+    `);
 
     // arrow after call-exp
     formatted = format(`string s=fn()->test();`);
-    expect(formatted).toMatchInlineSnapshot(`"string s = fn()->test();"`);
+    expect(formatted).toMatchInlineSnapshot(`
+      "string s = fn()->test();
+      "
+    `);
 
     // arrow after binary-exp in parens
     formatted = format(`string s=("obj"+"name")->test();`);
-    expect(formatted).toMatchInlineSnapshot(
-      `"string s = ("obj" + "name")->test();"`
-    );
+    expect(formatted).toMatchInlineSnapshot(`
+      "string s = ("obj" + "name")->test();
+      "
+    `);
 
     // arrow inside ternary after arrow
     formatted = format(`string s = obj->test()?obj->test2() : "";`);
-    expect(formatted).toMatchInlineSnapshot(
-      `"string s = obj->test() ? obj->test2() : "";"`
-    );
+    expect(formatted).toMatchInlineSnapshot(`
+      "string s = obj->test() ? obj->test2() : "";
+      "
+    `);
 
     // arrow with newlines
     formatted = format(`string s = obj
     ->
     test();`);
-    expect(formatted).toMatchInlineSnapshot(`"string s = obj->test();"`);
+    expect(formatted).toMatchInlineSnapshot(`
+      "string s = obj->test();
+      "
+    `);
 
     // arrow with suffix comment
     formatted = format(`string s = obj->fn(); // comment`);
-    expect(formatted).toMatchInlineSnapshot(
-      `"string s = obj->fn(); // comment"`
-    );
+    expect(formatted).toMatchInlineSnapshot(`
+      "string s = obj->fn(); // comment
+      "
+    `);
   });
 
   test("format foreach loops", () => {
@@ -453,9 +492,10 @@ describe("prettier-lpc plugin", () => {
 
     // functions with multiple parameters
     formatted = format(`test(int a, int b) { return a+b; }`);
-    expect(formatted).toMatchInlineSnapshot(
-      `"test(int a, int b) { return a + b; }"`
-    );
+    expect(formatted).toMatchInlineSnapshot(`
+      "test(int a, int b) { return a + b; }
+      "
+    `);
 
     // multiple params, declaration with multi variables
     formatted = format(
@@ -467,7 +507,8 @@ describe("prettier-lpc plugin", () => {
       test(string type, int b) {
         int foo, bar = 1;
         return type;
-      }"
+      }
+      "
     `);
   });
 
@@ -480,7 +521,8 @@ describe("prettier-lpc plugin", () => {
         string status;
         status = sprintf("Stutus number: %d
       ", status);
-      }"
+      }
+      "
     `);
   });
 
@@ -507,24 +549,28 @@ describe("prettier-lpc plugin", () => {
     expect(formatted).toMatchSnapshot("for_loop_various");
 
     formatted = format(`for (int i=0; i < 10; ++i) { }`);
-    expect(formatted).toMatchInlineSnapshot(
-      `"for (int i = 0; i < 10; ++i) {  }"`
-    );
+    expect(formatted).toMatchInlineSnapshot(`
+      "for (int i = 0; i < 10; ++i) {  }
+      "
+    `);
 
     formatted = format(`for (int i=0; i < 10; i++) { }`);
-    expect(formatted).toMatchInlineSnapshot(
-      `"for (int i = 0; i < 10; i++) {  }"`
-    );
+    expect(formatted).toMatchInlineSnapshot(`
+      "for (int i = 0; i < 10; i++) {  }
+      "
+    `);
 
     formatted = format(`for (int i=10; i > 0; --i) { }`);
-    expect(formatted).toMatchInlineSnapshot(
-      `"for (int i = 10; i > 0; --i) {  }"`
-    );
+    expect(formatted).toMatchInlineSnapshot(`
+      "for (int i = 10; i > 0; --i) {  }
+      "
+    `);
 
     formatted = format(`for (int i=10; i > 0; i--) { }`);
-    expect(formatted).toMatchInlineSnapshot(
-      `"for (int i = 10; i > 0; i--) {  }"`
-    );
+    expect(formatted).toMatchInlineSnapshot(`
+      "for (int i = 10; i > 0; i--) {  }
+      "
+    `);
 
     formatted = format(`void test() { while(true) {if (1==1)continue ;}}`);
     expect(formatted).toMatchSnapshot("loop-continue-shouldhave-semi");
@@ -549,41 +595,72 @@ describe("prettier-lpc plugin", () => {
 
   test("format literal characters", () => {
     let formatted = format(`test() { int i='j'; }`);
-    expect(formatted).toMatchInlineSnapshot(`"test() { int i = 'j'; }"`);
+    expect(formatted).toMatchInlineSnapshot(`
+      "test() { int i = 'j'; }
+      "
+    `);
 
     formatted = format(`test() { fn('a'); }`);
-    expect(formatted).toMatchInlineSnapshot(`"test() { fn('a'); }"`);
+    expect(formatted).toMatchInlineSnapshot(`
+      "test() { fn('a'); }
+      "
+    `);
 
     formatted = format(`test() { fn('\\n'); }`);
-    expect(formatted).toMatchInlineSnapshot(`"test() { fn('\\n'); }"`);
+    expect(formatted).toMatchInlineSnapshot(`
+      "test() { fn('\\n'); }
+      "
+    `);
 
     formatted = format(`test() { int i='\\n'; }`);
-    expect(formatted).toMatchInlineSnapshot(`"test() { int i = '\\n'; }"`);
+    expect(formatted).toMatchInlineSnapshot(`
+      "test() { int i = '\\n'; }
+      "
+    `);
 
     formatted = format(`test() { int i='\\n'+'a'; }`);
-    expect(formatted).toMatchInlineSnapshot(
-      `"test() { int i = '\\n' + 'a'; }"`
-    );
+    expect(formatted).toMatchInlineSnapshot(`
+      "test() { int i = '\\n' + 'a'; }
+      "
+    `);
   });
 
   test("format indexors", () => {
     let formatted = format(`string s = a[0..2]`);
-    expect(formatted).toMatchInlineSnapshot(`"string s = a[0..2];"`);
+    expect(formatted).toMatchInlineSnapshot(`
+      "string s = a[0..2];
+      "
+    `);
 
     formatted = format(`string s = a[ 0..]`);
-    expect(formatted).toMatchInlineSnapshot(`"string s = a[0..];"`);
+    expect(formatted).toMatchInlineSnapshot(`
+      "string s = a[0..];
+      "
+    `);
 
     formatted = format(`string s = a[0..<2]`);
-    expect(formatted).toMatchInlineSnapshot(`"string s = a[0..<2];"`);
+    expect(formatted).toMatchInlineSnapshot(`
+      "string s = a[0..<2];
+      "
+    `);
 
     formatted = format(`string s = a[<1..<2]`);
-    expect(formatted).toMatchInlineSnapshot(`"string s = a[<1..<2];"`);
+    expect(formatted).toMatchInlineSnapshot(`
+      "string s = a[<1..<2];
+      "
+    `);
 
     formatted = format(`string s = a[<1]`);
-    expect(formatted).toMatchInlineSnapshot(`"string s = a[<1];"`);
+    expect(formatted).toMatchInlineSnapshot(`
+      "string s = a[<1];
+      "
+    `);
 
     formatted = format(`string s = a[ <1.. <2]`);
-    expect(formatted).toMatchInlineSnapshot(`"string s = a[<1..<2];"`);
+    expect(formatted).toMatchInlineSnapshot(`
+      "string s = a[<1..<2];
+      "
+    `);
 
     // deep mapping indexors
     formatted = format(
@@ -593,13 +670,17 @@ describe("prettier-lpc plugin", () => {
       "void test() {
         printf("%O
       ", animals["bird"]["age"]["born"]["date"]["time"]);
-      }"
+      }
+      "
     `);
   });
 
   test("handle string literals with escaped quotes", () => {
     let formatted = format(`string s = "testing\\" 123";`);
-    expect(formatted).toMatchInlineSnapshot(`"string s = "testing\\" 123";"`);
+    expect(formatted).toMatchInlineSnapshot(`
+      "string s = "testing\\" 123";
+      "
+    `);
 
     formatted = format(`string s = "testing\\" 123\\\\";`);
     expect(formatted).toMatchSnapshot("literal_strings_multiple_escapes");
@@ -608,13 +689,17 @@ describe("prettier-lpc plugin", () => {
   test("function declarations", () => {
     // fluffos version with no variable name
     let formatted = format(`string evaluate_path(string);`);
-    expect(formatted).toMatchInlineSnapshot(`"string evaluate_path(string);"`);
+    expect(formatted).toMatchInlineSnapshot(`
+      "string evaluate_path(string);
+      "
+    `);
 
     // LD version
     formatted = format(`string evaluate_path(string s);`);
-    expect(formatted).toMatchInlineSnapshot(
-      `"string evaluate_path(string s);"`
-    );
+    expect(formatted).toMatchInlineSnapshot(`
+      "string evaluate_path(string s);
+      "
+    `);
   });
 
   describe("inherit statements", () => {
@@ -647,10 +732,26 @@ describe("prettier-lpc plugin", () => {
   describe("function calls", () => {
     test("handles multiple arguments", () => {
       let formatted = format(`test() { fn("a","b"); }`);
-      expect(formatted).toMatchInlineSnapshot(`"test() { fn("a", "b"); }"`);
+      expect(formatted).toMatchInlineSnapshot(`
+        "test() { fn("a", "b"); }
+        "
+      `);
 
       formatted = format(`test() { fn("a", -1); }`);
-      expect(formatted).toMatchInlineSnapshot(`"test() { fn("a", -1); }"`);
+      expect(formatted).toMatchInlineSnapshot(`
+        "test() { fn("a", -1); }
+        "
+      `);
+    });
+  });
+
+  describe("root", () => {
+    test("should always end with newline", () => {
+      let formatted = format(`test() { fn("a"); }`);
+      expect(formatted).toMatchInlineSnapshot(`
+        "test() { fn("a"); }
+        "
+      `);
     });
   });
 
@@ -689,9 +790,10 @@ describe("prettier-lpc plugin", () => {
     test("Closures", () => {
       // fluffos $() syntax
       let formatted = format(`int *arr=filter(arr2,(:$(var):));`);
-      expect(formatted).toMatchInlineSnapshot(
-        `"int *arr = filter(arr2, (: $(var) :));"`
-      );
+      expect(formatted).toMatchInlineSnapshot(`
+        "int *arr = filter(arr2, (: $(var) :));
+        "
+      `);
     });
 
     // end FluffOS

--- a/src/plugin/print/var.ts
+++ b/src/plugin/print/var.ts
@@ -7,6 +7,8 @@ import {
 } from "../../nodeTypes/variableDeclaration";
 import { printSuffixComments } from "./comment";
 import { needsSemi, PrintNodeFunction } from "./shared";
+import { shouldPrintPairs } from "../../utils/arrays";
+import { IdentifierNode } from "../../nodeTypes/identifier";
 
 const {
   group,
@@ -80,6 +82,13 @@ export const printVar: PrintNodeFunction<
   if (init) {
     arr.push(" =");
     const shouldIndent = init.type != "array" && init.type != "mapping";
+    
+    // figure out if init is array and should be printed in pairs
+    let nm:string|undefined = "";
+    if (id?.type == "identifier") nm = (id as IdentifierNode).name;
+    else if (id?.type == "assignment") nm = (id as any).left.name;
+    shouldPrintPairs(nm, options, init);
+
     const printedInit = path.call(printChildren, "init");
     if (shouldIndent) {
       arr.push(group(indent([line, printedInit])));

--- a/src/plugin/print/var.ts
+++ b/src/plugin/print/var.ts
@@ -7,8 +7,7 @@ import {
 } from "../../nodeTypes/variableDeclaration";
 import { printSuffixComments } from "./comment";
 import { needsSemi, PrintNodeFunction } from "./shared";
-import { shouldPrintPairs } from "../../utils/arrays";
-import { IdentifierNode } from "../../nodeTypes/identifier";
+
 
 const {
   group,
@@ -82,13 +81,7 @@ export const printVar: PrintNodeFunction<
   if (init) {
     arr.push(" =");
     const shouldIndent = init.type != "array" && init.type != "mapping";
-    
-    // figure out if init is array and should be printed in pairs
-    let nm:string|undefined = "";
-    if (id?.type == "identifier") nm = (id as IdentifierNode).name;
-    else if (id?.type == "assignment") nm = (id as any).left.name;
-    shouldPrintPairs(nm, options, init);
-
+        
     const printedInit = path.call(printChildren, "init");
     if (shouldIndent) {
       arr.push(group(indent([line, printedInit])));

--- a/src/utils/arrays.ts
+++ b/src/utils/arrays.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ArrayExpressionNode } from "../nodeTypes/arrayExpression";
+import { AstPath } from "prettier";
 import { LPCNode } from "../nodeTypes/lpcNode";
 import { LPCOptions } from "../plugin";
 
@@ -82,21 +82,5 @@ export function someReverse<T>(
     }
   }
 
-  return false;
-}
-
-export function shouldPrintPairs(
-  varName: string | undefined,
-  options: LPCOptions,
-  node: LPCNode
-) {
-  const pairVars = new Set(options.pairVariables);
-  if (node.type == "array") {
-    const arrNode = node as ArrayExpressionNode;
-    if (!!varName && pairVars.has(varName)) {
-      arrNode.printAsPairs = true;
-      return true;
-    }
-  }
   return false;
 }

--- a/src/utils/arrays.ts
+++ b/src/utils/arrays.ts
@@ -3,69 +3,100 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { ArrayExpressionNode } from "../nodeTypes/arrayExpression";
+import { LPCNode } from "../nodeTypes/lpcNode";
+import { LPCOptions } from "../plugin";
+
 /**
  * Takes a sorted array and a function p. The array is sorted in such a way that all elements where p(x) is false
  * are located before all elements where p(x) is true.
  * @returns the least x for which p(x) is true or array.length if no element fullfills the given function.
  */
-export function findFirst<T>(array: T[], p: (x: T|undefined) => boolean): number {
-	let low = 0, high = array.length;
-	if (high === 0) {
-		return 0; // no children
-	}
-	while (low < high) {
-		let mid = Math.floor((low + high) / 2);
-		if (p(array[mid])) {
-			high = mid;
-		} else {
-			low = mid + 1;
-		}
-	}
-	return low;
+export function findFirst<T>(
+  array: T[],
+  p: (x: T | undefined) => boolean
+): number {
+  let low = 0,
+    high = array.length;
+  if (high === 0) {
+    return 0; // no children
+  }
+  while (low < high) {
+    let mid = Math.floor((low + high) / 2);
+    if (p(array[mid])) {
+      high = mid;
+    } else {
+      low = mid + 1;
+    }
+  }
+  return low;
 }
 
-export function binarySearch<T>(array: T[], key: T, comparator: (op1: T|undefined, op2: T) => number): number {
-	let low = 0,
-		high = array.length - 1;
+export function binarySearch<T>(
+  array: T[],
+  key: T,
+  comparator: (op1: T | undefined, op2: T) => number
+): number {
+  let low = 0,
+    high = array.length - 1;
 
-	while (low <= high) {
-		const mid = ((low + high) / 2) | 0;
-		const comp = comparator(array[mid], key);
-		if (comp < 0) {
-			low = mid + 1;
-		} else if (comp > 0) {
-			high = mid - 1;
-		} else {
-			return mid;
-		}
-	}
-	return -(low + 1);
+  while (low <= high) {
+    const mid = ((low + high) / 2) | 0;
+    const comp = comparator(array[mid], key);
+    if (comp < 0) {
+      low = mid + 1;
+    } else if (comp > 0) {
+      high = mid - 1;
+    } else {
+      return mid;
+    }
+  }
+  return -(low + 1);
 }
 
 export function last<T>(array: T[]): T | undefined {
-	if (array.length > 0) return array[array.length-1];
-	return undefined;
+  if (array.length > 0) return array[array.length - 1];
+  return undefined;
 }
 
 export function first<T>(array: T[]): T | undefined {
-	if (array.length > 0) return array[0];
-	return undefined;
+  if (array.length > 0) return array[0];
+  return undefined;
 }
 
 export function pushIfVal<T>(array: T[], val: T) {
-	if (!!val) {
-		array.push(val);
-		return true;
-	} 
-	return false;
+  if (!!val) {
+    array.push(val);
+    return true;
+  }
+  return false;
 }
 
-export function someReverse<T>(array: T[], predicate:(value: T)=>boolean): boolean {
-	for(let i=array.length-1; i >= 0; i--) {
-		if (predicate(array[i])) {			
-			return true;
-		}
-	}
+export function someReverse<T>(
+  array: T[],
+  predicate: (value: T) => boolean
+): boolean {
+  for (let i = array.length - 1; i >= 0; i--) {
+    if (predicate(array[i])) {
+      return true;
+    }
+  }
 
-	return false;
+  return false;
+}
+
+export function shouldPrintPairs(
+  varName: string | undefined,
+  options: LPCOptions,
+  node: LPCNode
+) {
+  const pairVars = new Set(options.pairVariables);
+  if (node.type == "array") {
+    const arrNode = node as ArrayExpressionNode;
+    if (!!varName && pairVars.has(varName)) {
+      arrNode.printAsPairs = true;
+      return true;
+    }
+  }
+  return false;
 }


### PR DESCRIPTION
Adds support for "array pairs", the ability to arrays assigned to common variables in "pair" mode (i.e. two elements per line). 
Example:

```
dest_dir = ({
  "room1", "north",
  "room2", "south"
});
```

This mode is triggered based on a user-configurable list of variable names (e.g. `dest_dir`) or by the comment hint: `// @prettier-pair`